### PR TITLE
Feature/24

### DIFF
--- a/components/DiaryWrite.tsx
+++ b/components/DiaryWrite.tsx
@@ -1,159 +1,27 @@
-/* eslint-disable padded-blocks */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 // style
 import { DiaryWriteWrapper } from './diary/write/styled';
 
-// services
-import { createDiary } from 'services/diary';
-
 interface IProps {
   diaryId: any;
+  diaryForm: any;
+  diaryFormHandler: (e: any) => void;
+  stamps: [];
+  stampHandler: (e: any) => void;
+  uploadImage: (e: any) => void;
+  submitDiaryForm: () => void;
 }
 
-const DiaryWrite = ({ diaryId }: IProps) => {
-  // console.log('diaryId ==> ', diaryId);
-
-  // state 선언
-  const [pet, setPet] = useState('곰곰');
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [file, setFile] = useState<any>([]);
-  const [stamps, setStamps] = useState<any>([]);
-
-  const [requestDto, setRequestDto] = useState<any>({
-    pet: { petName: '' },
-    title: '',
-    content: '',
-    stamps: [],
-  });
-
-  // requestDto = {
-  //   pet: { petName: string },
-  //   title: string,
-  //   content: string,
-  //   stamps: [
-  //     { stampType: string }, { stampType: string }
-  //   ],
-  // }
-
-  // multipartFile: images
-
-  // title
-  const handleTitle = (e: any) => {
-    e.preventDefault();
-    setTitle(e.target.value);
-    console.log(e.target.value);
-  };
-
-  // content
-  const handleContent = (e: any) => {
-    e.preventDefault();
-    setContent(e.target.value);
-    console.log(e.target.value);
-  };
-
-  // file
-  const handleFile = (e: any) => {
-    e.preventDefault();
-
-    if (e.target.files) {
-      setFile(e.target.files[0]);
-      console.log(file);
-    }
-  };
-
-  // stamptype
-  const handleStamps = (e: any) => {
-    // console.log(e.currentTarget.dataset);
-    const { type } = e.currentTarget.dataset;
-    let tmpArr = [...stamps];
-    tmpArr.push({ stampType: type });
-    setStamps(tmpArr);
-    console.log(tmpArr);
-  };
-
-  useEffect(() => {
-    setRequestDto({
-      pet: { petName: pet },
-      title,
-      content,
-      stamps,
-    });
-  }, [pet, title, content, stamps]);
-
-  console.log(requestDto);
-
-  // 등록 onClick
-  const submitDiaryForm = (e: any) => {
-    e.preventDefault();
-    // const requestDto: any = { title, content, stamps };
-    // console.log(requestDto);
-    const formData = new FormData();
-    console.log('22', requestDto);
-    Array.from(file).map((file: any, key: number) => {
-      formData.append('multipartFile', file);
-    });
-
-    formData.append('requestDto', requestDto);
-
-    createDiary(formData)
-      .then((res) => {
-        console.log(res);
-        // if 요청 성공시 처리할 코드 else 요청 실패
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-    // form 초기화
-    // setTitle('');
-    // setContent('');
-    // setStamps({
-    //   WALK: false,
-    //   TREAT: false,
-    //   TOY: false,
-    //   TRAVEL: false,
-    // });
-  };
-
-  // 📌📌📌📌📌📌📌📌📌 230224 axios 요청 예시 📌📌📌📌📌📌📌📌📌
-  // const [requestDto, setRequestDto] = useState<any>({
-  //   pet: { petName: '' },
-  //   title: '',
-  //   content: '',
-  //   stamps: [{ stampType: '' }],
-  // });
-  // const [file, setFile] = useState([]);
-  // const [thumbnail, setThumbnail] = useState<any>();
-
-  // const uploadImage = (e: any) => {
-  //   setFile(e.target.files);
-
-  //   const preview = URL.createObjectURL(e.target.files[0]);
-  //   setThumbnail(preview);
-  // };
-
-  // const submitDiaryForm = () => {
-  //   const fd = new FormData();
-
-  //   Array.from(file).map((file: any, key: number) => {
-  //     fd.append('multipartFile', file);
-  //   });
-
-  //   fd.append('requestDto', requestDto);
-
-  //   createDiary(fd)
-  //     .then((res) => {
-  //       console.log(res);
-  //       // if 요청 성공시 처리할 코드 else 요청 실패
-  //     })
-  //     .catch((err) => {
-  //       console.error(err);
-  //     });
-  // };
-
-  // return <>{diaryId ? <h1>일기 수정 페이지</h1> : <h1>일기 작성 페이지</h1>}</>;
-
+const DiaryWrite = ({
+  diaryId,
+  diaryForm,
+  diaryFormHandler,
+  stamps,
+  stampHandler,
+  uploadImage,
+  submitDiaryForm,
+}: IProps) => {
   return (
     <DiaryWriteWrapper>
       <div className="write-wrap">
@@ -170,7 +38,7 @@ const DiaryWrite = ({ diaryId }: IProps) => {
             type="text"
             className="inputfield-title"
             placeholder="ex) 곰곰이와 0일째"
-            onChange={handleTitle}
+            onChange={diaryFormHandler}
             required // 필수값
           />
         </div>
@@ -180,50 +48,47 @@ const DiaryWrite = ({ diaryId }: IProps) => {
             name="content"
             className="inputfield-content"
             placeholder="자유롭게 작성하세요:)"
-            onChange={handleContent}
+            onChange={diaryFormHandler}
           ></textarea>
         </div>
-        <form>
-          <div className="write-photo">
-            <span>사진</span>
-            <label className="photo-label" htmlFor="profileImg">
-              <img style={{ width: '40px' }} src="/images/add-photo.png" id="image" />
-            </label>
-            <input
-              type="file"
-              className="photo-input"
-              accept="image/*"
-              multiple={true}
-              id="profileImg"
-              onChange={handleFile}
-              required
-            />
-          </div>
-        </form>
+
+        <div className="write-photo">
+          <span>사진</span>
+          <label className="photo-label" htmlFor="profileImg">
+            <img style={{ width: '40px' }} src="/images/add-photo.png" id="image" />
+          </label>
+          <input
+            type="file"
+            className="photo-input"
+            accept="image/*"
+            multiple
+            id="profileImg"
+            onChange={uploadImage}
+            required
+            name="multipartFile"
+          />
+        </div>
+
         <div className="write-stamp">
           <span>다시 봄 스탬프</span>
         </div>
         <div className="write-stamp-inner">
-          <img src="/images/stamp4.png" data-type={'WALK'} onClick={handleStamps} />
-          <img src="/images/stamp1.png" data-type={'TREAT'} onClick={handleStamps} />
-          <img src="/images/stamp3.png" data-type={'TOY'} onClick={handleStamps} />
-          <img src="/images/stamp2.png" data-type={'TRAVEL'} onClick={handleStamps} />
+          <img src="/images/stamp4.png" data-type={'WALK'} onClick={stampHandler} />
+          <img src="/images/stamp1.png" data-type={'TREAT'} onClick={stampHandler} />
+          <img src="/images/stamp3.png" data-type={'TOY'} onClick={stampHandler} />
         </div>
         <br />
         <br />
         <div className="upload-btn">
-          <button type="submit" onClick={submitDiaryForm}>
-            등록
-          </button>
+          <button onClick={submitDiaryForm}>등록</button>
         </div>
 
         {/* input값 모두 받았는지 확인 */}
-        {/* {JSON.stringify({
-          title,
-          content,
-          file,
+        {JSON.stringify({
+          title: diaryForm.title,
+          content: diaryForm.content,
           stamps,
-        })} */}
+        })}
       </div>
     </DiaryWriteWrapper>
   );

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -4,9 +4,6 @@ import React, { useState } from 'react';
 // style
 import { DiaryCardWrapper } from './styled';
 
-// axios(서버연결)
-import axios from 'axios';
-
 interface IProps {
   item: any;
 }
@@ -41,14 +38,17 @@ const DiaryCard = ({ item }: IProps) => {
     <DiaryCardWrapper>
       <div className="card-wrap">
         <div className="date">
-          <span>23.01.30 18:00</span>
+          <span>{item?.createdAt}</span>
         </div>
         <div className="content-wrap">
           <div className="content-inner">
-            <h3 className="title">#단추처럼 #생긴 #코</h3>
+            <h3 className="title">
+              {/* {`#${item?.petName}`} */}
+              {item?.title}
+            </h3>
             <div className="diary-images" onClick={() => router.push(`/diary/${item.petId}`)} />
 
-            <p className="content">우리 곰곰이는 털도 매력이지만 코가 귀엽다</p>
+            <p className="content" dangerouslySetInnerHTML={{ __html: item?.content }} />
           </div>
           <div className="bottom-wrap">
             <div

--- a/components/diary/list/styled.tsx
+++ b/components/diary/list/styled.tsx
@@ -3,5 +3,5 @@ import styled from 'styled-components';
 export const DiaryListWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  height: 100%;
+  height: 100vh;
 `;

--- a/container/DiarySingleContainer.tsx
+++ b/container/DiarySingleContainer.tsx
@@ -10,7 +10,7 @@ import { getDiarySingle } from 'services/diary';
 
 const DiarySingleContainer = () => {
   const router = useRouter();
-  const [diaryId, setDiaryId] = useState<any>();
+  const [diaryId, setDiaryId] = useState<any>(1);
   const [item, setItem] = useState<any>();
 
   useEffect(() => {
@@ -18,13 +18,18 @@ const DiarySingleContainer = () => {
       setDiaryId(Number(router.query.diary_id));
     }
 
-    // getDiarySingle({ diaryId })
-    //   .then((res) => {
-    //     console.log(res);
-    //   })
-    //   .catch((err) => {
-    //     console.error(err);
-    //   });
+    getDiarySingle({ diaryId })
+      .then((res) => {
+        if (res.status === 200) {
+          const { data } = res;
+          setItem(data);
+        } else {
+          console.log('getDiarySingle fail');
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
   }, [router.query]);
 
   return (

--- a/container/DiaryWriteContainer.tsx
+++ b/container/DiaryWriteContainer.tsx
@@ -1,17 +1,102 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 
 // component
 import Layout from 'components/common/Layout/Layout';
 import DiaryWrite from 'components/DiaryWrite';
 
+// services
+import { createDiary, uploadFile } from 'services/diary';
+
 const DiaryWriteContainer = () => {
   const router = useRouter();
   const diaryId = router.query.diary_id;
 
+  // 제목, 본문
+  const [diaryForm, setDiaryForm] = useState({
+    petName: 'gomgom',
+    title: '',
+    content: '',
+  });
+
+  const diaryFormHandler = (e: any) => {
+    e.preventDefault();
+
+    const { name, value } = e.target;
+    setDiaryForm({ ...diaryForm, [name]: value });
+  };
+
+  // 스탬프
+  const [stamps, setStamps] = useState<any>([]);
+  const stampHandler = (e: any) => {
+    const { type } = e.currentTarget.dataset;
+    let tmpArr = [...stamps];
+
+    const itemToFind = tmpArr.find((item: any, key: number) => {
+      return item.stampType === type;
+    });
+
+    if (itemToFind) {
+      const idx = tmpArr.indexOf(itemToFind);
+      tmpArr.splice(idx, 1);
+    } else {
+      tmpArr.push({ stampType: type });
+    }
+
+    setStamps(tmpArr);
+  };
+
+  // 이미지 업로드
+  const [file, setFile] = useState<any>([]);
+  const uploadImage = (e: any) => {
+    e.preventDefault();
+    setFile(e.target.files);
+
+    const fd = new FormData();
+    Array.from(e.target.files).map((file: any) => {
+      fd.append('multipartFile', file);
+    });
+
+    uploadFile(fd)
+      .then((res) => {
+        console.log(res);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  // 등록
+  const submitDiaryForm = () => {
+    createDiary({
+      pet: { petName: diaryForm.petName },
+      title: diaryForm.title,
+      content: diaryForm.content,
+      stamps,
+    })
+      .then((res) => {
+        console.log(res);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  // console.log('diaryForm => ', diaryForm);
+  // console.log('stamps => ', stamps);
+  // console.log('file => ', file);
+
   return (
     <Layout>
-      <DiaryWrite diaryId={diaryId} />
+      <DiaryWrite
+        diaryId={diaryId}
+        diaryForm={diaryForm}
+        diaryFormHandler={diaryFormHandler}
+        stamps={stamps}
+        stampHandler={stampHandler}
+        uploadImage={uploadImage}
+        submitDiaryForm={submitDiaryForm}
+      />
     </Layout>
   );
 };

--- a/services/defaultClient.tsx
+++ b/services/defaultClient.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const nameSpace = '';
-export const baseURL = 'https://3.34.234.124:8080';
+export const baseURL = 'http://3.34.234.124:8080';
 
 const initAxios = () => {
   const defaultClient = axios.create({

--- a/services/diary.tsx
+++ b/services/diary.tsx
@@ -13,9 +13,21 @@ export interface ICreateDiary {
   multipartFile: any;
 }
 
+// 일기 작성
 export const createDiary = async (args: any) => {
   const axios = initAxios();
-  return await axios.post(`${prefix}/save`, args, {
+  return await axios.post('/diary/save/text', {
+    pet: args.pet,
+    title: args.title,
+    content: args.content,
+    stamps: args.stamps,
+  });
+};
+
+// 이미지 업로드
+export const uploadFile = async (args: any) => {
+  const axios = initAxios();
+  return await axios.post(`${prefix}/save/file`, args, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });
 };


### PR DESCRIPTION
### 🧐 Motivation
- 일기 작성 api 연동
- 일기 상세 조회 api 연동 및 데이터 바인딩
- DiaryWrite 코드 리팩토링
- defaultClient baseURL 수정
- diary service 일기 작성과 이미지 업로드 분리

<br>

### 🎯 Key Changes
- 일기 작성 시 이미지 업로드에서 이슈가 있어서 민주님과 논의한 끝에 텍스트 폼과 이미지 api를 분리해서 따로 요청하기로 했습니다.
  이미지를 제외한 나머지 값들을 보내고 요청 성공하는 것까지 확인하였습니다.
- 아직 일기 리스트가 없기 때문에 임시로 petId: 1 게시물로 상세 조회 api를 요청해서 간략하게 데이터 바인딩 작업을 했습니다.
- DiartWrite.tsx에 있는 코드를 DiartWriteContainer.tsx로 옮기고 이벤트 핸들러들이 잘 작동하는지 확인하였습니다.
  코드를 옮긴 이유는 기능 로직은 최대한 Container에서 작성하고 각 자식 컴포넌트는 레이아웃 코드 위주로 작성하기 위해서입니다!
  또, 기능이 많아지면 코드도 같이 길어져서 가독성이 안 좋아지기 때문에 이를 보완하기 위해서입니다!
- baseURL(서버가 배포한 주소)를 제가 착각해서 다르게 작성했고 이로 인해서 api 요청에 이슈가 있었습니다! 그래서 알맞은 url로 다시 수정했습니다!
- 일기 작성 시 텍스트 폼과 이미지 업로드를 분리하기로 해서 axios 함수도 분리했습니다.

<br>

### 💬 To Reviewers
- develop 브랜치에 병합이 되면 develop에서 pull을 받아 최신화하시고 이슈 생성해서 작업하시면 됩니다! api 연동 작업은 백엔드와 소통이 중요하기 때문에 작업하시다가 막히거나 궁금한 점이 있으실 때 바로바로 백엔드 분들이나 저한테 말씀 주시면 감사하겠습니다!

close #24 
