### PR TITLE
Feature/30

### DIFF
--- a/components/DiarySingleAgain.tsx
+++ b/components/DiarySingleAgain.tsx
@@ -9,8 +9,11 @@ import 'slick-carousel/slick/slick-theme.css';
 // style
 import { DiarySingleAgainWrapper } from './diary/again/styled';
 
-const DiarySingleAgain = () => {
+interface IProps {}
+
+const DiarySingleAgain = ({}: IProps) => {
   const router = useRouter();
+  const { stampType, petName } = router.query;
 
   const settings = {
     dots: false,
@@ -21,50 +24,71 @@ const DiarySingleAgain = () => {
   return (
     <DiarySingleAgainWrapper>
       <Slider {...settings}>
-        <div className="again-inner">
-          <div className="again-image"></div>
-          <div className="again-content-wrap">
-            <div className="again-title">곰곰 다이어리</div>
-            <div className="again-content">
-              곰곰이는 00님과
-              <br /> 22년 2월 1일부터 23년 1월 31일까지
-              <br /> 365일 함께 했어요
-            </div>
-            <div className="step-btn" onClick={() => router.push('/diary/again/letter')}>
-              곰곰이와의 추억을 열어보세요 {'>'}
+        {petName === 'gomgom' && (
+          <div className="again-inner">
+            <div className="again-image"></div>
+            <div className="again-content-wrap">
+              <div className="again-title">곰곰 다이어리</div>
+              <div className="again-content">
+                곰곰이는 00님과
+                <br /> 22년 2월 1일부터 23년 1월 31일까지
+                <br /> 365일 함께 했어요
+              </div>
+              <div
+                className="step-btn"
+                onClick={() =>
+                  router.push(`/diary/again/letter?stampType=${stampType}&petName=${petName}`)
+                }
+              >
+                곰곰이와의 추억을 열어보세요 {'>'}
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
-        <div className="again-inner">
-          <div className="again-image again-image2"></div>
-          <div className="again-content-wrap">
-            <div className="again-title">달리 다이어리</div>
-            <div className="again-content">
-              달리는 00님과
-              <br /> 22년 2월 1일부터 23년 1월 31일까지
-              <br /> 365일 함께 했어요
-            </div>
-            <div className="step-btn" onClick={() => router.push('/diary/again/letter')}>
-              달리와의 추억을 열어보세요 {'>'}
+        {petName === 'dangdang' && (
+          <div className="again-inner">
+            <div className="again-image again-image2"></div>
+            <div className="again-content-wrap">
+              <div className="again-title">당당 다이어리</div>
+              <div className="again-content">
+                당당이는 00님과
+                <br /> 22년 2월 1일부터 23년 1월 31일까지
+                <br /> 365일 함께 했어요
+              </div>
+              <div
+                className="step-btn"
+                onClick={() =>
+                  router.push(`/diary/again/letter?stampType=${stampType}&petName=${petName}`)
+                }
+              >
+                당당이와의 추억을 열어보세요 {'>'}
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
-        <div className="again-inner">
-          <div className="again-image again-image3"></div>
-          <div className="again-content-wrap">
-            <div className="again-title">밀라 다이어리</div>
-            <div className="again-content">
-              밀라는 00님과
-              <br /> 22년 2월 1일부터 23년 1월 31일까지
-              <br /> 365일 함께 했어요
-            </div>
-            <div className="step-btn" onClick={() => router.push('/diary/again/letter')}>
-              밀라와의 추억을 열어보세요 {'>'}
+        {petName === 'bongbong' && (
+          <div className="again-inner">
+            <div className="again-image again-image3"></div>
+            <div className="again-content-wrap">
+              <div className="again-title">밀라 다이어리</div>
+              <div className="again-content">
+                봉봉이는 00님과
+                <br /> 22년 2월 1일부터 23년 1월 31일까지
+                <br /> 365일 함께 했어요
+              </div>
+              <div
+                className="step-btn"
+                onClick={() =>
+                  router.push(`/diary/again/letter?stampType=${stampType}&petName=${petName}`)
+                }
+              >
+                봉봉이와의 추억을 열어보세요 {'>'}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </Slider>
     </DiarySingleAgainWrapper>
   );

--- a/components/diary/again/styled.tsx
+++ b/components/diary/again/styled.tsx
@@ -58,7 +58,11 @@ export const DiarySingleAgainWrapper = styled.div`
   }
 
   .step-btn {
-    margin-top: 80px;
+    font-size: 16px;
+    margin-top: 60px;
+    background-color: #fff;
+    padding: 10px;
+    border-radius: 20px;
     cursor: pointer;
   }
 

--- a/components/diary/letter/index.tsx
+++ b/components/diary/letter/index.tsx
@@ -6,13 +6,44 @@ import { DiarySingleLetterWrapper } from './styled';
 
 const DiarySingleLetter = () => {
   const router = useRouter();
+  const { stampType } = router.query;
 
   return (
     <DiarySingleLetterWrapper>
       <div className="letter-wrap">
         <div className="letter-title">곰곰이와 산책했던 시간</div>
         <div className="letter-img"></div>
-        <div className="letter-date" onClick={() => router.push('/diary/again/letter/0')}>
+        <div
+          className="letter-date"
+          onClick={() => router.push(`/diary/again/letter/0?stampType=${stampType}&petName=gomgom`)}
+        >
+          23년 1월 25일에 쓴<br />
+          일기가 날아왔어요
+        </div>
+      </div>
+      {}
+      <div className="letter-wrap">
+        <div className="letter-title">당당이와 산책했던 시간</div>
+        <div className="letter-img"></div>
+        <div
+          className="letter-date"
+          onClick={() =>
+            router.push(`/diary/again/letter/0?stampType=${stampType}&petName=dangdang`)
+          }
+        >
+          23년 1월 25일에 쓴<br />
+          일기가 날아왔어요
+        </div>
+      </div>
+      <div className="letter-wrap">
+        <div className="letter-title">봉봉이와 산책했던 시간</div>
+        <div className="letter-img"></div>
+        <div
+          className="letter-date"
+          onClick={() =>
+            router.push(`/diary/again/letter/0?stampType=${stampType}&petName=bongbong`)
+          }
+        >
           23년 1월 25일에 쓴<br />
           일기가 날아왔어요
         </div>

--- a/components/diary/letter/styled.tsx
+++ b/components/diary/letter/styled.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 export const DiarySingleLetterWrapper = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
   background-color: #f2f9ff;
-  padding-top: 80px;
+  padding-top: 40px;
 
   .letter-wrap {
     width: 325px;
@@ -14,7 +14,7 @@ export const DiarySingleLetterWrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 0 auto;
+    margin: 50px auto;
     padding: 60px 20px;
   }
 

--- a/components/home/index.tsx
+++ b/components/home/index.tsx
@@ -4,20 +4,39 @@ import React from 'react';
 // style
 import { HomeWrapper } from './styled';
 
-const Home = () => {
+interface IProps {
+  endProtection: () => void;
+  isEnded: boolean;
+  warningMessage: () => void;
+  pet: any;
+}
+
+const Home = ({ endProtection, isEnded, warningMessage, pet }: IProps) => {
   const router = useRouter();
 
   return (
     <HomeWrapper>
       <div className="profile-wrap">
-        <div className="profile-inner">
-          <div className="write-btn" onClick={() => router.push('/diary/write')}>
-            <div className="bg1"></div>
-            <span>일기쓰기</span>
+        <div className="profile-btn-inner">
+          <div className="profile-inner">
+            <div className="write-btn" onClick={() => router.push('/diary/write')}>
+              <div className="bg1"></div>
+              <span>일기쓰기</span>
+            </div>
+            <div
+              className="again-btn"
+              onClick={() =>
+                isEnded
+                  ? router.push(`/diary/again?stampType=WALK&petName=${pet?.petName}`)
+                  : warningMessage()
+              }
+            >
+              <div className="bg2"></div>
+              <span>다시보기</span>
+            </div>
           </div>
-          <div className="again-btn" onClick={() => router.push('/diary/again')}>
-            <div className="bg2"></div>
-            <span>다시보기</span>
+          <div className="finish-btn" onClick={endProtection}>
+            <span>임시보호 종료하기</span>
           </div>
         </div>
       </div>

--- a/components/home/styled.tsx
+++ b/components/home/styled.tsx
@@ -7,6 +7,8 @@ export const HomeWrapper = styled.div`
     background-color: #f2f9ff;
     padding-top: 200px;
   }
+  .profile-btn-inner {
+  }
   .profile-inner {
     width: 100%;
     height: 200px;
@@ -27,6 +29,25 @@ export const HomeWrapper = styled.div`
         font-weight: 600;
       }
     }
+  }
+  .finish-btn {
+    width: 200px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 50px auto;
+
+    font-size: 24px;
+    font-family: 'JejuGothic';
+    font-style: normal;
+    font-weight: 600;
+    background-color: #fff;
+    border-radius: 12px;
+    cursor: pointer;
+  }
+  .finish-btn:hover {
+    color: gray;
   }
   .bg1 {
     background-image: url('../../images/lucky.jpg');

--- a/components/letterList/index.tsx
+++ b/components/letterList/index.tsx
@@ -12,7 +12,13 @@ import { DiarySingleLetterListWrapper } from './styled';
 // kakao
 import useSNSShare from './useSNSShare';
 
-const DiarySingleLetterList = () => {
+interface IProps {
+  petInfo: any;
+  type: string;
+  name: string;
+}
+
+const DiarySingleLetterList = ({ petInfo, type, name }: IProps) => {
   const router = useRouter();
 
   const settings = {
@@ -21,45 +27,47 @@ const DiarySingleLetterList = () => {
     speed: 500,
   };
 
-  const tmpArr = Array.from({ length: 5 }, (_: any, key: number) => {
-    return {
-      date: `23.01.25 17:0${key}`,
-      title: `#곰곰이와 산책했던 시간${key + 1}`,
-      content:
-        '오늘 곰곰이랑 양평 강아지 놀이터에 갔다. 곰곰이가 다른 강아지랑 잘 놀아서 얼마나 좋던지!😊',
-    };
-  });
-
   return (
     <DiarySingleLetterListWrapper>
       <div className="title-wrap">
-        <h3>곰곰이와 산책했던 시간</h3>
+        <h3>
+          {name === 'gomgom'
+            ? '곰곰'
+            : name === 'dangdang'
+            ? '당당'
+            : name === 'bongbong'
+            ? '봉봉'
+            : ''}
+          이와{' '}
+          {type === 'WALK' ? '산책' : type === 'TREAT' ? '간식' : type === 'TOY' ? '장난감' : ''}
+          했던 시간
+        </h3>
       </div>
-      <Slider {...settings}>
-        {tmpArr && tmpArr.length
-          ? tmpArr.map((item: any, key: number) => (
-              <div key={key} className="slide-wrap carousel">
-                <p className="date">{item.date}</p>
-                <p className="title">{item.title}</p>
-                <div className="content-img" />
+      {petInfo && petInfo.length > 0 && (
+        <>
+          <Slider {...settings}>
+            {petInfo && petInfo.length
+              ? petInfo.map((item: any, key: number) => (
+                  <div key={key} className="slide-wrap carousel">
+                    <p className="date">{item.date}</p>
+                    <p className="title">{item.title}</p>
+                    <div className="content-img" />
 
-                <p className="content">{item.content}</p>
+                    <p className="content">{item.content}</p>
 
-                <img src="/images/share.png" alt="" />
-              </div>
-            ))
-          : ''}
-      </Slider>
-      <div className="ios-share-img">
-        <img 
-          src="/images/ios-share.png" 
-          alt="카카오로 공유하기"
-          onClick={useSNSShare}
-        />
-      </div>
-      <div className="bottom-btn" onClick={() => router.push('/diary')}>
-        <span>곰곰이 일기 다시보기</span>
-      </div>
+                    <img src="/images/share.png" alt="" />
+                  </div>
+                ))
+              : ''}
+          </Slider>
+          <div className="ios-share-img">
+            <img src="/images/ios-share.png" alt="카카오로 공유하기" onClick={useSNSShare} />
+          </div>
+          <div className="bottom-btn" onClick={() => router.push('/diary')}>
+            <span>곰곰이 일기 다시보기</span>
+          </div>
+        </>
+      )}
     </DiarySingleLetterListWrapper>
   );
 };

--- a/container/DiarySingleLetterListContainer.tsx
+++ b/container/DiarySingleLetterListContainer.tsx
@@ -1,13 +1,52 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 
 // component
 import Layout from 'components/common/Layout/Layout';
 import DiarySingleLetterList from 'components/letterList';
 
+// services
+import { getAgainDiary } from 'services/diary';
+
 const DiarySingleLetterListContainer = () => {
+  const router = useRouter();
+  const { stampType, petName } = router.query;
+  const [type, setType] = useState<any>();
+  const [name, setName] = useState<any>();
+
+  const [petInfo, setPetInfo] = useState<any>();
+
+  useEffect(() => {
+    if (stampType && petName) {
+      setType(stampType);
+      setName(petName);
+    }
+  }, [router.query]);
+
+  useEffect(() => {
+    if (stampType && petName) {
+      // console.log(stampType);
+      // console.log(petName);
+
+      getAgainDiary({
+        stampType,
+        petName,
+      })
+        .then((res) => {
+          console.log(res.data);
+          if (res.status === 200) {
+            setPetInfo(res.data);
+          }
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
+  }, [stampType, petName]);
+
   return (
     <Layout>
-      <DiarySingleLetterList />
+      <DiarySingleLetterList petInfo={petInfo} type={type} name={name} />
     </Layout>
   );
 };

--- a/container/HomeContainer.tsx
+++ b/container/HomeContainer.tsx
@@ -1,13 +1,49 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 // component
 import Home from 'components/home';
 import Layout from 'components/common/Layout/Layout';
 
+// services
+import { finishProtection } from 'services/diary';
+
+// toast
+import { toast } from 'react-toastify';
+
 const HomeContainer = () => {
+  // 임시보호 종료
+  const [pet, setPet] = useState({ petName: 'dangdang' });
+  const [isEnded, setIsEnded] = useState<boolean>(false);
+
+  const endProtection = () => {
+    finishProtection({ pet })
+      .then((res) => {
+        if (res.status === 200) {
+          setIsEnded(true);
+          toast.success(res.data.message, {
+            autoClose: 2000,
+          });
+        } else {
+          setIsEnded(false);
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  };
+
+  const warningMessage = () => {
+    toast.error('임시보호를 종료해 주세요.', { autoClose: 2000 });
+  };
+
   return (
     <Layout>
-      <Home />
+      <Home
+        endProtection={endProtection}
+        isEnded={isEnded}
+        warningMessage={warningMessage}
+        pet={pet}
+      />
     </Layout>
   );
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-slick": "^0.29.0",
+    "react-toastify": "^9.1.1",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.6",
     "styled-reset": "^4.4.5",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,10 @@ import { ThemeProvider } from 'styled-components';
 import GlobalStyle from 'styles/global-styles';
 import theme from 'styles/theme';
 
+// toast
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
 // 모든 페이지 컴포넌트를 감싸고 있는 공통 레이아웃(가장 최초로 실행됨)
 // 이후 _document.tsx가 실행
 function MyApp({ Component, pageProps }: AppProps) {
@@ -16,6 +20,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>다시, 봄</title>
       </Head>
+      <ToastContainer />
       <GlobalStyle />
       <ThemeProvider theme={theme}>
         <Component {...pageProps} />

--- a/services/diary.tsx
+++ b/services/diary.tsx
@@ -85,18 +85,25 @@ export const deleteDiary = async (args: IDiaryId) => {
   return await axios.delete(`${prefix}/${args.diaryId}`, {});
 };
 
-// 다시 보기
-interface IGetAgainDiary {
-  petId: number;
-  stampType: 'WALK' | 'TREAT' | 'TOY';
+// 임시보호 종료
+interface IFinishProtection {
+  pet: { petName: string };
 }
 
-export const getAgainDiary = async (args: IGetAgainDiary) => {
+export const finishProtection = async (args: IFinishProtection) => {
   const axios = initAxios();
-  return await axios.get(`${prefix}/again`, {
+  return await axios.post('/protection/end', {
+    pet: args.pet,
+  });
+};
+
+// 다시 보기
+export const getAgainDiary = async (args: any) => {
+  const axios = initAxios();
+  return await axios.get(`${prefix}/list/record`, {
     params: {
-      petId: args.petId,
       stampType: args.stampType,
+      petName: args.petName,
     },
   });
 };

--- a/styles/global-styles.ts
+++ b/styles/global-styles.ts
@@ -35,6 +35,10 @@ ${reset}
       font-size: 10px;
     }
   }
+
+  .Toastify__toast-container {
+  z-index: 999999999 !important;
+}
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
### 🧐 Motivation
- 임시보호 종료, 다시 보기 api 연동

<br>

### 🎯 Key Changes
- 임시보호 종료 api가 추가되고, 다시 보기 api 세부사항이 변경돼서 axios 함수에서도 반영했습니다.
- 홈 화면에서 임시보호 종료 버튼을 추가하고 종료 api 연동하였습니다. 종료 안하고 다시 보기 선택 시 toast 팝업으로 경고문을 띄웠습니다!
- stampType과 petName을 쿼리로 페이지 이동한 컴포넌트에 각각 전달하였습니다.
- 전달받은 stampType, petName을 이용해서 조건부 렌더링을 적용하고, 다시 보기 api 연동 한 후에 데이터 바인딩을 했습니다!

<br>

### 💬 To Reviewers
- 확인해 주시고 머지 부탁드립니다! 된 후에 develop에서 pull 받으시고 `yarn add` 해주시면 됩니다!
- 위와 같이 진행이 된 후에 이슈 생성해서 작업하시면 됩니다!
close #30 